### PR TITLE
Copy entire image from native memory in one pass

### DIFF
--- a/example/src/main/java/io/github/chrisribble/ffmpeg/example/BufferedImageStreamSpliterator.java
+++ b/example/src/main/java/io/github/chrisribble/ffmpeg/example/BufferedImageStreamSpliterator.java
@@ -90,7 +90,6 @@ public final class BufferedImageStreamSpliterator implements Spliterator<Buffere
 
 	private Resolution srcResolution;
 	private Resolution dstResolution;
-	private byte[] lineBuffer;
 	private BufferedImage templateImage;
 
 	private int frameNumber;
@@ -178,7 +177,6 @@ public final class BufferedImageStreamSpliterator implements Spliterator<Buffere
 		if (dstResolution == null) {
 			dstResolution = srcResolution;
 		}
-		lineBuffer = new byte[dstResolution.width() * pixelFormat.bytesPerPixel()];
 		templateImage = new BufferedImage(1, 1, pixelFormat.bufferedImageType());
 
 		int srcPixels = srcResolution.width() * srcResolution.height();
@@ -281,36 +279,31 @@ public final class BufferedImageStreamSpliterator implements Spliterator<Buffere
 	private BufferedImage getBufferedImage(final MemorySegment frame, final Resolution resolution) {
 		int width = resolution.width();
 		int height = resolution.height();
-		int bytesPerPixel = pixelFormat.bytesPerPixel();
 
 		// uint8_t *data[8]
 		var data = AVFrame.data(frame);
 		// frame.data[0]
 		var pdata = data.get(C_POINTER, 0);
 		// frame.linespace[0]
-		var linesize = AVFrame.linesize(frame).get(C_INT, 0);
+		int linesize = AVFrame.linesize(frame).get(C_INT, 0);
 
-		byte[] imageBuffer = new byte[width * height * bytesPerPixel];
+		int imageBytes = linesize * height;
 
-		// Copy pixel data
-		for (int y = 0; y < height; y++) {
-			var pixelArray = pdata.asSlice((long) y * linesize)
-					.reinterpret((long) width * bytesPerPixel, arena, null);
-			ByteBuffer buffer = pixelArray.asByteBuffer();
-			buffer.get(lineBuffer);
+		var pixelArray = pdata.reinterpret(imageBytes, arena, null);
+		ByteBuffer buffer = pixelArray.asByteBuffer();
 
-			if (pixelFormat == PixelFormat.RGB) {
-				/*
-				 * FFmpeg supports RGB24, but BufferedImage only supports:
-				 * - TYPE_3BYTE_BGR (blue and red bytes are swapped)
-				 * - TYPE_INT_RGB (4-byte integer encoding with alpha)
-				 * Simple/naive solution is to just swap B <-> R.
-				 * There is likely a more elegant way to do this.
-				 */
-				PixelFormatConverter.rgbToBgr(lineBuffer);
-			}
+		byte[] imageBuffer = new byte[imageBytes];
+		buffer.get(imageBuffer);
 
-			System.arraycopy(lineBuffer, 0, imageBuffer, y * width * bytesPerPixel, lineBuffer.length);
+		if (pixelFormat == PixelFormat.RGB) {
+			/*
+			 * FFmpeg supports RGB24, but BufferedImage only supports:
+			 * - TYPE_3BYTE_BGR (blue and red bytes are swapped)
+			 * - TYPE_INT_RGB (4-byte integer encoding with alpha)
+			 * Simple/naive solution is to just swap B <-> R.
+			 * There is likely a more elegant way to do this.
+			 */
+			PixelFormatConverter.rgbToBgr(imageBuffer);
 		}
 
 		ColorModel colorModel = templateImage.getColorModel();


### PR DESCRIPTION
Avoid using an intermediate line buffer and copying bytes twice.