### PR TITLE
Memory safety / correctness / consistency fixes

### DIFF
--- a/analyzer/src/main/java/io/github/chrisribble/ffm/ffmpeg/analyzer/MediaAnalyzer.java
+++ b/analyzer/src/main/java/io/github/chrisribble/ffm/ffmpeg/analyzer/MediaAnalyzer.java
@@ -8,6 +8,8 @@ import static io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg.av_fourcc_make_st
 import static io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg.av_packet_alloc;
 import static io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg.av_packet_unref;
 import static io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg.av_read_frame;
+import static io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg$shared.C_POINTER;
+import static java.lang.foreign.MemorySegment.NULL;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -28,6 +30,7 @@ import io.github.chrisribble.ffm.ffmpeg.bindings.AVStream;
 import io.github.chrisribble.ffm.ffmpeg.bindings.FFmpeg;
 import io.github.chrisribble.ffm.ffmpeg.core.Rational;
 import io.github.chrisribble.ffm.ffmpeg.core.Resolution;
+import io.github.chrisribble.ffm.ffmpeg.core.exception.AVAllocateException;
 import io.github.chrisribble.ffm.ffmpeg.core.internal.AVFormatContextUtil;
 import io.github.chrisribble.ffm.ffmpeg.core.internal.AVStreamUtil;
 import io.github.chrisribble.ffm.ffmpeg.core.internal.LibavVersion;
@@ -242,7 +245,16 @@ public final class MediaAnalyzer {
 	private MemorySegment allocatePacket(final Arena arena) {
 		// AVPacket*
 		var p = av_packet_alloc();
-		return p.reinterpret(arena, FFmpeg::av_packet_free);
+		requireNonNull(p, "av_packet_alloc failed");
+
+		pointer(arena, p).reinterpret(arena, FFmpeg::av_packet_free);
+		return p;
+	}
+
+	private MemorySegment pointer(final Arena arena, final MemorySegment segment) {
+		var pointer = arena.allocate(C_POINTER);
+		pointer.set(C_POINTER, 0, MemorySegment.ofAddress(segment.address()));
+		return pointer;
 	}
 
 	private FrameRateMode getFrameRateMode(final StreamInfo videoStream) {
@@ -256,6 +268,15 @@ public final class MediaAnalyzer {
 
 	private boolean doubleEquals(final double a, final double b) {
 		return Math.abs(a - b) <= EPSILON;
+	}
+
+	private static void requireNonNull(final MemorySegment segment, final String message) throws AVAllocateException {
+		if (segment == null) {
+			throw new IllegalArgumentException("segment must be non-null");
+		}
+		if (segment.equals(NULL)) {
+			throw new AVAllocateException(message);
+		}
 	}
 
 	public record MediaInfo(ContainerInfo container, VideoInfo video, AudioInfo audio) {}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'com.github.ben-manes.versions' version '0.53.0'
+	id 'com.github.ben-manes.versions' version '0.54.0'
 	id 'se.solrike.sonarlint' version '2.2.0' apply false
-	id 'com.github.spotbugs' version '6.4.8' apply false
+	id 'com.github.spotbugs' version '6.5.4' apply false
 }
 
 

--- a/core/src/main/java/io/github/chrisribble/ffm/ffmpeg/core/internal/StreamInfo.java
+++ b/core/src/main/java/io/github/chrisribble/ffm/ffmpeg/core/internal/StreamInfo.java
@@ -1,5 +1,7 @@
 package io.github.chrisribble.ffm.ffmpeg.core.internal;
 
+import static java.lang.foreign.MemorySegment.NULL;
+
 import java.lang.foreign.MemorySegment;
 
 import io.github.chrisribble.ffm.ffmpeg.bindings.AVCodecParameters;
@@ -27,13 +29,13 @@ public final class StreamInfo {
 		if (avStream == null) {
 			throw new IllegalArgumentException("avStream must be non-null");
 		}
-		if (avStream == MemorySegment.NULL) {
+		if (avStream.equals(NULL)) {
 			throw new IllegalArgumentException("avStream must be a non-NULL pointer");
 		}
 		if (avCodecParams == null) {
 			throw new IllegalArgumentException("avCodecParams must be non-null");
 		}
-		if (avCodecParams == MemorySegment.NULL) {
+		if (avCodecParams.equals(NULL)) {
 			throw new IllegalArgumentException("avCodecParams must be a non-NULL pointer");
 		}
 

--- a/decoder/src/main/java/io/github/chrisribble/ffm/ffmpeg/decoder/BufferedImageSpliterator.java
+++ b/decoder/src/main/java/io/github/chrisribble/ffm/ffmpeg/decoder/BufferedImageSpliterator.java
@@ -327,6 +327,7 @@ public final class BufferedImageSpliterator implements Spliterator<BufferedImage
 
 		// AVCodecContext*
 		var pDecoderCtx = avcodec_alloc_context3(pCodec);
+		requireNonNull(pDecoderCtx, "codec context allocation failed");
 
 		// Register cleanup
 		pointer(pDecoderCtx)
@@ -352,16 +353,9 @@ public final class BufferedImageSpliterator implements Spliterator<BufferedImage
 		var context = sws_getContext(srcResolution.width(), srcResolution.height(), pixFmt,
 				dstResolution.width(), dstResolution.height(), pixelFormat.ffmpegType(),
 				SWS_BILINEAR(), NULL, NULL, NULL);
-		return context.reinterpret(arena, FFmpeg::sws_freeContext);
-	}
+		requireNonNull(context, "sws_getContext lookup failed");
 
-	private static void requireNonNull(final MemorySegment segment, final String message) throws AVAllocateException {
-		if (segment == null) {
-			throw new IllegalArgumentException("segment must be non-null");
-		}
-		if (segment.equals(NULL)) {
-			throw new AVAllocateException(message);
-		}
+		return context.reinterpret(arena, FFmpeg::sws_freeContext);
 	}
 
 	private MemorySegment allocateBuffer(final Resolution resolution) {
@@ -372,19 +366,27 @@ public final class BufferedImageSpliterator implements Spliterator<BufferedImage
 
 		// void*
 		var buf = av_malloc(bufferBytes * C_CHAR.byteSize());
+		requireNonNull(buf, "av_malloc failed");
+
 		return buf.reinterpret(arena, FFmpeg::av_free);
 	}
 
 	private MemorySegment allocateFrame() {
 		// AVFrame*
-		var frame = av_frame_alloc();
-		return frame.reinterpret(arena, FFmpeg::av_free);
+		var f = av_frame_alloc();
+		requireNonNull(f, "av_frame_alloc failed");
+
+		pointer(f).reinterpret(arena, FFmpeg::av_frame_free);
+		return f;
 	}
 
 	private MemorySegment allocatePacket() {
 		// AVPacket*
 		var p = av_packet_alloc();
-		return p.reinterpret(arena, FFmpeg::av_packet_free);
+		requireNonNull(p, "av_packet_alloc failed");
+
+		pointer(p).reinterpret(arena, FFmpeg::av_packet_free);
+		return p;
 	}
 
 	/**
@@ -408,6 +410,15 @@ public final class BufferedImageSpliterator implements Spliterator<BufferedImage
 		var pointer = arena.allocate(C_POINTER);
 		pointer.set(C_POINTER, 0, MemorySegment.ofAddress(segment.address()));
 		return pointer;
+	}
+
+	private static void requireNonNull(final MemorySegment segment, final String message) throws AVAllocateException {
+		if (segment == null) {
+			throw new IllegalArgumentException("segment must be non-null");
+		}
+		if (segment.equals(NULL)) {
+			throw new AVAllocateException(message);
+		}
 	}
 
 	public static final class Builder {


### PR DESCRIPTION
Changes:
- Add NULL checks for C functions that can return NULL
- av_frame_free accepts AVFrame**, not AVFrame*
- av_packet_free accepts AVPacket**, not AVPacket*
- Consistently use MemorySegment.equals for NULL C pointer check